### PR TITLE
Set table height to 100%

### DIFF
--- a/BlitzExt/blitzallpulls.html
+++ b/BlitzExt/blitzallpulls.html
@@ -123,7 +123,7 @@
 	}
 	
 	#pullRequestTableContainer{
-		height: 700px !important;
+		height: 100%;
 		overflow: scroll;
 	}
 </style>


### PR DESCRIPTION
I don't know if there is a reason to have the table height set to a fixed height. But it seems to work with height set to 100%.
