### PR TITLE
Set max height on the repositories multiselect

### DIFF
--- a/scripts/blitzallpulls.js
+++ b/scripts/blitzallpulls.js
@@ -129,6 +129,7 @@ function initializeMultiselect(repositories) {
 
 			// Initialize multiselect
 			$("#repositories-select").multiselect({
+				maxHeight: 200,
 				includeSelectAllOption: true,
 				nonSelectedText: 'Select repositories',
 				onDeselectAll: updateByRepository,


### PR DESCRIPTION
This adds a max height to the repositories multiselect.
Without a `maxHeight` the multiselect seem to overflow and there is no visible scrollbar. 

For a project with a lot of repositories this can be troublesome. 